### PR TITLE
Return response always

### DIFF
--- a/datadog/middleware/request_handler.py
+++ b/datadog/middleware/request_handler.py
@@ -33,7 +33,7 @@ class DatadogMiddleware(object):
     def process_response(self, request, response):
         """ Submit timing metrics from the current request """
         if not hasattr(request, self.DD_TIMING_ATTRIBUTE):
-            return
+            return response
 
         # Calculate request time and submit to Datadog
         request_time = time.time() - getattr(request, self.DD_TIMING_ATTRIBUTE)


### PR DESCRIPTION
Making sure `process_response()` always returns a response (otherwise it will cause failures in the following middlewares)
